### PR TITLE
Add PAT login prompt to launch script.

### DIFF
--- a/openbb_platform_pro_backend/main.py
+++ b/openbb_platform_pro_backend/main.py
@@ -197,10 +197,6 @@ def launch_api():
 
         current_settings = new_settings
 
-    if current_settings["credentials"].get("OPENAI_API_KEY"):
-        print("\n\nOpenAI API Key found, adding to the environment variables.\n")
-        os.environ["OPENAI_API_KEY"] = current_settings["credentials"]["OPENAI_API_KEY"]
-
     host = os.getenv("OPENBB_API_HOST", "127.0.0.1")
     if not host:
         print(

--- a/openbb_platform_pro_backend/main.py
+++ b/openbb_platform_pro_backend/main.py
@@ -1,15 +1,34 @@
 """Generate and serve the widgets.json for the OpenBB Platform API."""
 
 import json
-
+import os
+import socket
+from pathlib import Path
 from fastapi.responses import JSONResponse
 from openbb_core.api.rest_api import app
+
 
 from .utils import (
     get_data_schema_for_widget,
     get_query_schema_for_widget,
     data_schema_to_columns_defs,
 )
+
+CURRENT_USER_SETTINGS = os.environ.get("HOME") + "/.openbb_platform/user_settings.json"
+USER_SETTINGS_COPY = CURRENT_USER_SETTINGS.replace("user_settings.json", "user_settings_copy.json")
+
+
+def check_port(port) -> int:
+    """Check if the port number is free."""
+    not_free = True
+    port = int(port) - 1
+    while not_free:
+        port = port + 1
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            res = sock.connect_ex(("localhost", port))
+            if res != 0:
+                not_free = False
+    return port
 
 
 openapi = app.openapi()
@@ -99,25 +118,131 @@ async def get_widgets():
 # pylint: disable=import-outside-toplevel
 def launch_api():
     """Main function."""
-    import os
     import uvicorn
+
+    if Path(CURRENT_USER_SETTINGS).exists():
+        with open(CURRENT_USER_SETTINGS, "r") as f:
+            current_settings = json.load(f)
+    else:
+        current_settings = {"credentials": {}, "preferences": {}, "defaults": {"commands": {}}}
+
+    pat = input(
+        "\n\nEnter your personal access token (PAT) to authorize the API and update your local settings."
+        + "\nSkip to use a pre-configured 'user_settings.json' file."
+        + "\nPress Enter to skip or copy your PAT to the command line: "
+    )
+
+    if pat:
+        from openbb_core.app.service.hub_service import HubService
+
+        try:
+            Hub = HubService()
+            _ = Hub.connect(pat=pat)
+            hub_settings = Hub.pull()
+            hub_credentials = json.loads(hub_settings.credentials.model_dump_json())
+            hub_preferences = json.loads(hub_settings.preferences.model_dump_json())
+            hub_defaults = json.loads(hub_settings.defaults.model_dump_json())
+        except Exception as e:
+            print(f"\n\nError connecting with Hub:\n{e}")
+            hub_credentials = {}
+            hub_preferences = {}
+            hub_defaults = {}
+
+        # Prompt the user to ask if they want to persist the new settings
+        persist_input = input(
+            "\n\nDo you want to persist the new settings?"
+            + " Not recommended for public machines. (yes/no): "
+        ).strip().lower()
+
+        if persist_input in ["yes", "y"]:
+            PERSIST = True
+        elif persist_input in ["no", "n"]:
+            PERSIST = False
+        else:
+            print("\n\nInvalid input. Defaulting to not persisting the new settings.")
+            PERSIST = False
+
+        # Save the current settings to restore at the end of the session.
+        if PERSIST is False:
+            with open(USER_SETTINGS_COPY, "w") as f:
+                json.dump(current_settings, f, indent=4)
+
+        new_settings = current_settings.copy()
+
+        # Update the current settings with the new settings
+        if hub_credentials:
+            for k, v in hub_credentials.items():
+                if v:
+                    new_settings["credentials"][k] = v
+
+        if hub_preferences:
+            for k, v in hub_credentials.items():
+                if v:
+                    new_settings["preferences"][k] = v
+            new_settings["preferences"].update(hub_preferences)
+
+        if hub_defaults:
+            for k, v in hub_defaults.items():
+                if k == "commands":
+                    for key, value in hub_defaults["commands"].items():
+                        if value:
+                            new_settings["defaults"]["commands"][key] = value
+                elif v:
+                    new_settings["defaults"][k] = v
+                else:
+                    continue
+            new_settings["defaults"].update(hub_defaults)
+
+        # Write the new settings to the user_settings.json file
+        with open(CURRENT_USER_SETTINGS, "w") as f:
+            json.dump(new_settings, f, indent=4)
+
+        current_settings = new_settings
+
+    if current_settings["credentials"].get("OPENAI_API_KEY"):
+        print("\n\nOpenAI API Key found, adding to the environment variables.\n")
+        os.environ["OPENAI_API_KEY"] = current_settings["credentials"]["OPENAI_API_KEY"]
 
     host = os.getenv("OPENBB_API_HOST", "127.0.0.1")
     if not host:
-        raise ValueError(
-            "OPENBB_API_HOST is set incorrectly. It should be an IP address or hostname."
+        print(
+            "\n\nOPENBB_API_HOST is set incorrectly. It should be an IP address or hostname."
         )
+        host = input("Enter the host IP address or hostname: ")
+        if not host:
+            host = "127.0.0.1"
 
     port = os.getenv("OPENBB_API_PORT", 8000)
+
     try:
         port = int(port)
     except ValueError:
-        raise ValueError(
-            "OPENBB_API_PORT is set incorrectly. It should be an port number."
+        print(
+            "\n\nOPENBB_API_PORT is set incorrectly. It should be an port number."
         )
+        port = input("Enter the port number: ")
+        try:
+            port = int(port)
+        except ValueError:
+            print("\n\nInvalid port number. Defaulting to 8000.")
+            port = 8000
 
-    uvicorn.run("openbb_platform_pro_backend.main:app", host=host, port=port)
+    free_port = check_port(port)
 
+    if free_port != port:
+        print(f"\n\nPort {port} is already in use. Using port {free_port}.\n")
+        port = free_port
+
+    try:
+        uvicorn.run("openbb_platform_pro_backend.main:app", host=host, port=port)
+    finally:
+        # If user_settings_copy.json exists, then restore the original settings.
+        if os.path.exists(USER_SETTINGS_COPY):
+            print("\n\nRestoring the original settings.\n")
+            os.replace(USER_SETTINGS_COPY, CURRENT_USER_SETTINGS)
 
 if __name__ == "__main__":
-    launch_api()
+    try:
+        launch_api()
+    except KeyboardInterrupt:
+        print("Restoring the original settings.")

--- a/openbb_platform_pro_backend/main.py
+++ b/openbb_platform_pro_backend/main.py
@@ -178,7 +178,6 @@ def launch_api():
             for k, v in hub_credentials.items():
                 if v:
                     new_settings["preferences"][k] = v
-            new_settings["preferences"].update(hub_preferences)
 
         if hub_defaults:
             for k, v in hub_defaults.items():

--- a/openbb_platform_pro_backend/main.py
+++ b/openbb_platform_pro_backend/main.py
@@ -226,6 +226,7 @@ def launch_api():
             print("\n\nInvalid port number. Defaulting to 8000.")
             port = 8000
     if port < 1025:
+        port = 8000
         print("\n\nInvalid port number, must be above 1024. Defaulting to 8000.")
 
     free_port = check_port(host, port)

--- a/openbb_platform_pro_backend/main.py
+++ b/openbb_platform_pro_backend/main.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from fastapi.responses import JSONResponse
 from openbb_core.api.rest_api import app
 
-
 from .utils import (
     get_data_schema_for_widget,
     get_query_schema_for_widget,

--- a/openbb_platform_pro_backend/main.py
+++ b/openbb_platform_pro_backend/main.py
@@ -190,7 +190,6 @@ def launch_api():
                     new_settings["defaults"][k] = v
                 else:
                     continue
-            new_settings["defaults"].update(hub_defaults)
 
         # Write the new settings to the user_settings.json file
         with open(CURRENT_USER_SETTINGS, "w") as f:

--- a/openbb_platform_pro_backend/main.py
+++ b/openbb_platform_pro_backend/main.py
@@ -17,14 +17,14 @@ CURRENT_USER_SETTINGS = os.environ.get("HOME") + "/.openbb_platform/user_setting
 USER_SETTINGS_COPY = CURRENT_USER_SETTINGS.replace("user_settings.json", "user_settings_copy.json")
 
 
-def check_port(port) -> int:
+def check_port(host, port) -> int:
     """Check if the port number is free."""
     not_free = True
     port = int(port) - 1
     while not_free:
         port = port + 1
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-            res = sock.connect_ex(("localhost", port))
+            res = sock.connect_ex((host, port))
             if res != 0:
                 not_free = False
     return port
@@ -225,7 +225,7 @@ def launch_api():
             print("\n\nInvalid port number. Defaulting to 8000.")
             port = 8000
 
-    free_port = check_port(port)
+    free_port = check_port(host, port)
 
     if free_port != port:
         print(f"\n\nPort {port} is already in use. Using port {free_port}.\n")


### PR DESCRIPTION
This PR:

- Adds a Hub login prompt (can be bypassed) to update `user_settings.json` with values from Hub.
- Prompt for persistence, if no the downloaded changes are removed on `KeyboardInterrupt`.
- Adds a check to determine if the port is actually free.
- When bad host/port values are in the ENV, adds an input prompt instead of raising.